### PR TITLE
Update Cart.php, fix CartItem::fromAttributes call

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ The shoppingcart gives you the following methods to use:
 
 Adding an item to the cart is really simple, you just use the `add()` method, which accepts a variety of parameters.
 
-In its most basic form you can specify the id, name, quantity, price of the product you'd like to add to the cart.
+In its most basic form you can specify the id, name, quantity, price and weight of the product you'd like to add to the cart.
 
 ```php
-Cart::add('293ad', 'Product 1', 1, 9.99);
+Cart::add('293ad', 'Product 1', 1, 9.99, 550);
 ```
 
 As an optional fifth parameter you can pass it options, so you can add multiple items with the same id, but with (for instance) a different size.
 
 ```php
-Cart::add('293ad', 'Product 1', 1, 9.99, 'weight' => 550, ['size' => 'large']);
+Cart::add('293ad', 'Product 1', 1, 9.99, 550, ['size' => 'large']);
 ```
 
 **The `add()` method will return an CartItem instance of the item you just added to the cart.**

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -105,11 +105,12 @@ class Cart
      * @param mixed     $name
      * @param int|float $qty
      * @param float     $price
+     * @param float     $weight
      * @param array     $options
      *
      * @return \Gloudemans\Shoppingcart\CartItem
      */
-    public function add($id, $name = null, $qty = null, $price = null, array $options = [])
+    public function add($id, $name = null, $qty = null, $price = null, $weight = null, array $options = [])
     {
         if ($this->isMulti($id)) {
             return array_map(function ($item) {
@@ -117,7 +118,7 @@ class Cart
             }, $id);
         }
 
-        $cartItem = $this->createCartItem($id, $name, $qty, $price, $options);
+        $cartItem = $this->createCartItem($id, $name, $qty, $price, $weight, $options);
 
         return $this->addCartItem($cartItem);
     }
@@ -696,11 +697,12 @@ class Cart
      * @param mixed     $name
      * @param int|float $qty
      * @param float     $price
+     * @param float     $weight
      * @param array     $options
      *
      * @return \Gloudemans\Shoppingcart\CartItem
      */
-    private function createCartItem($id, $name, $qty, $price, array $options)
+    private function createCartItem($id, $name, $qty, $price, $weight, array $options)
     {
         if ($id instanceof Buyable) {
             $cartItem = CartItem::fromBuyable($id, $qty ?: []);
@@ -710,7 +712,7 @@ class Cart
             $cartItem = CartItem::fromArray($id);
             $cartItem->setQuantity($id['qty']);
         } else {
-            $cartItem = CartItem::fromAttributes($id, $name, $price, null, $options);
+            $cartItem = CartItem::fromAttributes($id, $name, $price, $weight, $options);
             $cartItem->setQuantity($qty);
         }
 

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -710,7 +710,7 @@ class Cart
             $cartItem = CartItem::fromArray($id);
             $cartItem->setQuantity($id['qty']);
         } else {
-            $cartItem = CartItem::fromAttributes($id, $name, $price, $options);
+            $cartItem = CartItem::fromAttributes($id, $name, $price, null, $options);
             $cartItem->setQuantity($qty);
         }
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1155,7 +1155,7 @@ class CartTest extends TestCase
         // https://github.com/bumbummen99/LaravelShoppingcart/pull/5
         $cart = $this->getCart();
 
-        $cartItem  = $cart->add('293ad', 'Product 1', 1, 9.99, 550, ['size' => 'large']);
+        $cartItem = $cart->add('293ad', 'Product 1', 1, 9.99, 550, ['size' => 'large']);
 
         $this->assertEquals(550, $cartItem->weight);
         $this->assertTrue($cartItem->options->has('size'));

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1149,6 +1149,19 @@ class CartTest extends TestCase
         $this->assertEquals(2.50, $cart->tax(2)); // tax of 5 Bucks
     }
 
+    /** @test */
+    public function it_does_allow_adding_cart_items_with_weight_and_options()
+    {
+        // https://github.com/bumbummen99/LaravelShoppingcart/pull/5
+        $cart = $this->getCart();
+
+        $cartItem  = $cart->add('293ad', 'Product 1', 1, 9.99, 550, ['size' => 'large']);
+
+        $this->assertEquals(550, $cartItem->weight);
+        $this->assertTrue($cartItem->options->has('size'));
+        $this->assertEquals('large', $cartItem->options->size);
+    }
+
     /**
      * Get an instance of the cart.
      *


### PR DESCRIPTION
The CartItem::fromAttributes call is missing the $weight parameter, and the CartItemOptions don't work any more because of this.