### PR TITLE
Fix products sequence after changing cart item options

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -195,8 +195,7 @@ class Cart
 
             return;
         } else {
-            if (isset($itemOldIndex))
-            {
+            if (isset($itemOldIndex)) {
                 $content = $content->slice(0, $itemOldIndex)
                     ->merge([$cartItem->rowId => $cartItem])
                     ->merge($content->slice($itemOldIndex));

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -180,6 +180,8 @@ class Cart
         $content = $this->getContent();
 
         if ($rowId !== $cartItem->rowId) {
+            $itemOldIndex = $content->keys()->search($rowId);
+
             $content->pull($rowId);
 
             if ($content->has($cartItem->rowId)) {
@@ -193,7 +195,14 @@ class Cart
 
             return;
         } else {
-            $content->put($cartItem->rowId, $cartItem);
+            if (isset($itemOldIndex))
+            {
+                $content = $content->slice(0, $itemOldIndex)
+                    ->merge([$cartItem->rowId => $cartItem])
+                    ->merge($content->slice($itemOldIndex));
+            } else {
+                $content->put($cartItem->rowId, $cartItem);
+            }
         }
 
         $this->events->dispatch('cart.updated', $cartItem);

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -400,6 +400,21 @@ class CartTest extends TestCase
     }
 
     /** @test */
+    public function it_will_keep_items_sequence_if_the_options_changed()
+    {
+        $cart = $this->getCart();
+
+        $cart->add(new BuyableProduct(), 1, ['color' => 'red']);
+        $cart->add(new BuyableProduct(), 1, ['color' => 'green']);
+        $cart->add(new BuyableProduct(), 1, ['color' => 'blue']);
+
+        $cart->update($cart->content()->values()[1]->rowId, ['options' => ['color' => 'yellow']]);
+
+        $this->assertRowsInCart(3, $cart);
+        $this->assertEquals('yellow', $cart->content()->values()[1]->options->color);
+    }
+
+    /** @test */
     public function it_can_remove_an_item_from_the_cart()
     {
         Event::fake();


### PR DESCRIPTION
This PR fixes the problem with changing products sequence on updating cart items options.

Whenever you update your cart item using array it regenerates its own rowId. If you change any option of the item (for example color or size) - you will get a new rowId resulting in cart item rewriting in the collection and moving to the end of the list. 

This PR preserves item's original position in the collection while keeping its new rowId.