### PR TITLE
Added fluency to Cart.php

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -232,7 +232,7 @@ class Cart
         $this->events->dispatch('cart.removed', $cartItem);
 
         $this->session->put($this->instance, $content);
-        
+
         return $this;
     }
 
@@ -666,7 +666,7 @@ class Cart
         $this->instance($currentInstance);
 
         $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->delete();
-        
+
         return $this;
     }
 

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -219,7 +219,7 @@ class Cart
      *
      * @param string $rowId
      *
-     * @return void
+     * @return \Gloudemans\Shoppingcart\Cart
      */
     public function remove($rowId)
     {
@@ -232,6 +232,8 @@ class Cart
         $this->events->dispatch('cart.removed', $cartItem);
 
         $this->session->put($this->instance, $content);
+        
+        return $this;
     }
 
     /**
@@ -600,7 +602,7 @@ class Cart
      *
      * @param mixed $identifier
      *
-     * @return void
+     * @return \Gloudemans\Shoppingcart\Cart
      */
     public function store($identifier)
     {
@@ -621,6 +623,8 @@ class Cart
         ]);
 
         $this->events->dispatch('cart.stored');
+
+        return $this;
     }
 
     /**
@@ -628,7 +632,7 @@ class Cart
      *
      * @param mixed $identifier
      *
-     * @return void
+     * @return \Gloudemans\Shoppingcart\Cart
      */
     public function restore($identifier)
     {
@@ -662,6 +666,8 @@ class Cart
         $this->instance($currentInstance);
 
         $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->delete();
+        
+        return $this;
     }
 
     /**

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -869,7 +869,7 @@ class CartTest extends TestCase
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
 
         $this->assertInstanceOf(\Gloudemans\Shoppingcart\Cart::class, $store);
-        
+
         Event::assertDispatched('cart.stored');
     }
 
@@ -922,7 +922,7 @@ class CartTest extends TestCase
         $this->assertItemsInCart(1, $cart);
 
         $this->assertDatabaseMissing('shoppingcart', ['identifier' => $identifier, 'instance' => 'default']);
-        
+
         $this->assertInstanceOf(\Gloudemans\Shoppingcart\Cart::class, $restore);
 
         Event::assertDispatched('cart.restored');

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -423,10 +423,11 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct());
 
-        $cart->remove('027c91341fd5cf4d2579b49c4b6a90da');
+        $removed = $cart->remove('027c91341fd5cf4d2579b49c4b6a90da');
 
         $this->assertItemsInCart(0, $cart);
         $this->assertRowsInCart(0, $cart);
+        $this->assertInstanceOf(\Gloudemans\Shoppingcart\Cart::class, $removed);
 
         Event::assertDispatched('cart.removed');
     }
@@ -861,12 +862,14 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct());
 
-        $cart->store($identifier = 123);
+        $store = $cart->store($identifier = 123);
 
         $serialized = serialize($cart->content());
 
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
 
+        $this->assertInstanceOf(\Gloudemans\Shoppingcart\Cart::class, $store);
+        
         Event::assertDispatched('cart.stored');
     }
 
@@ -914,11 +917,13 @@ class CartTest extends TestCase
 
         $this->assertItemsInCart(0, $cart);
 
-        $cart->restore($identifier);
+        $restore = $cart->restore($identifier);
 
         $this->assertItemsInCart(1, $cart);
 
         $this->assertDatabaseMissing('shoppingcart', ['identifier' => $identifier, 'instance' => 'default']);
+        
+        $this->assertInstanceOf(\Gloudemans\Shoppingcart\Cart::class, $restore);
 
         Event::assertDispatched('cart.restored');
     }


### PR DESCRIPTION
Updated Cart.php to allow for fluent chaining for remove(), store(), and restore() methods by adding "return $this;" on each