### PR TITLE
Use current instance when checking if storedCartWithIdentifierExists

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ If you want to retrieve the cart from the database and restore it, all you have 
 If you want to merge the cart with another one from the database, all you have to do is call the  `merge($identifier)` where `$identifier` is the key you specified for the `store` method. You can also define if you want to keep the discount and tax rates of the items and if you want to dispatch "cart.added" events.
      
     // Merge the contents of 'savedcart' into 'username'.
-    Cart::instance('username')->merge('savedcart', $keepDiscount, $keepTaxrate, $dispatchAdd);
+    Cart::instance('username')->merge('savedcart', $keepDiscount, $keepTaxrate, $dispatchAdd, 'savedcartinstance');
 
 ### Erasing the cart
 If you want to erase the cart from the database, all you have to do is call the  `erase($identifier)` where `$identifier` is the key you specified for the `store` method.

--- a/README_Idn.md
+++ b/README_Idn.md
@@ -544,7 +544,7 @@ Jika Anda ingin mengambil keranjang dari database dan mengembalikannya, yang har
 Jika Anda ingin menggabungkan keranjang dengan keranjang lain dari basis data, yang harus Anda lakukan adalah memanggil `gabungan ($ identifier)` di mana `$ identifier` adalah kunci yang Anda tentukan untuk metode` store`. Anda juga dapat menentukan apakah Anda ingin mempertahankan potongan harga dan tarif pajak item.
      
     // Merge the contents of 'savedcart' into 'username'.
-    Cart::instance('username')->merge('savedcart', $keepDiscount, $keepTaxrate);
+    Cart::instance('username')->merge('savedcart', $keepDiscount, $keepTaxrate, 'savedcartinstance');
 
 ## Pengecualian
 

--- a/README_uk-UA.md
+++ b/README_uk-UA.md
@@ -542,7 +542,7 @@ foreach(Cart::content() as $row) {
 Якщо ви хочете злити кошик із іншим кошиком, збереженим у базі даних, вам знадобиться викликати метод `merge($identifier)`, де `$identifier` - це ключ, який ви зазначили у методі`store`. Ви також можете визначити чи хочете ви зберегти знижку і ставку оподаткування для товарів.
      
     // Merge the contents of 'savedcart' into 'username'.
-    Cart::instance('username')->merge('savedcart', $keepDiscount, $keepTaxrate);
+    Cart::instance('username')->merge('savedcart', $keepDiscount, $keepTaxrate, 'savedcartinstance');
 
 ## Перехоплення
 

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -831,7 +831,7 @@ class Cart
      */
     private function storedCartWithIdentifierExists($identifier)
     {
-        return $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->exists();
+        return $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->where('instance', $this->currentInstance())->exists();
     }
 
     /**

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -835,7 +835,7 @@ class Cart
         if ($this->countInstances() > 1) {
             $data['instance'] = $this->currentInstance();
         }
-        
+
         return $this->getConnection()->table($this->getTableName())->where($data)->exists();
     }
 

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -633,13 +633,15 @@ class Cart
             $identifier = $identifier->getInstanceIdentifier();
         }
 
-        if ($this->storedCartWithIdentifierExists($identifier)) {
+        $instance = $this->currentInstance();
+
+        if ($this->storedCartInstanceWithIdentifierExists($instance, $identifier)) {
             throw new CartAlreadyStoredException("A cart with identifier {$identifier} was already stored.");
         }
 
         $this->getConnection()->table($this->getTableName())->insert([
             'identifier' => $identifier,
-            'instance'   => $this->currentInstance(),
+            'instance'   => $instance,
             'content'    => serialize($content),
             'created_at' => $this->createdAt ?: Carbon::now(),
             'updated_at' => Carbon::now(),
@@ -661,16 +663,16 @@ class Cart
             $identifier = $identifier->getInstanceIdentifier();
         }
 
-        if (!$this->storedCartWithIdentifierExists($identifier)) {
+        $currentInstance = $this->currentInstance();
+
+        if (!$this->storedCartInstanceWithIdentifierExists($currentInstance, $identifier)) {
             return;
         }
 
         $stored = $this->getConnection()->table($this->getTableName())
-            ->where('identifier', $identifier)->first();
+            ->where(['identifier'=> $identifier,'instance' => $currentInstance])->first();
 
         $storedContent = unserialize(data_get($stored, 'content'));
-
-        $currentInstance = $this->currentInstance();
 
         $this->instance(data_get($stored, 'instance'));
 
@@ -689,7 +691,7 @@ class Cart
         $this->createdAt = Carbon::parse(data_get($stored, 'created_at'));
         $this->updatedAt = Carbon::parse(data_get($stored, 'updated_at'));
 
-        $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->delete();
+        $this->getConnection()->table($this->getTableName())->where(['identifier' => $identifier, 'instance' => $currentInstance])->delete();
     }
 
     /**
@@ -705,11 +707,13 @@ class Cart
             $identifier = $identifier->getInstanceIdentifier();
         }
 
-        if (!$this->storedCartWithIdentifierExists($identifier)) {
+        $instance = $this->currentInstance();
+
+        if (!$this->storedCartInstanceWithIdentifierExists($instance, $identifier)) {
             return;
         }
 
-        $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->delete();
+        $this->getConnection()->table($this->getTableName())->where(['identifier' => $identifier, 'instance' => $instance])->delete();
 
         $this->events->dispatch('cart.erased');
     }
@@ -724,14 +728,14 @@ class Cart
      *
      * @return bool
      */
-    public function merge($identifier, $keepDiscount = false, $keepTax = false, $dispatchAdd = true)
+    public function merge($identifier, $keepDiscount = false, $keepTax = false, $dispatchAdd = true, $instance = SELF::DEFAULT_INSTANCE)
     {
-        if (!$this->storedCartWithIdentifierExists($identifier)) {
+        if (!$this->storedCartInstanceWithIdentifierExists($instance, $identifier)) {
             return false;
         }
 
         $stored = $this->getConnection()->table($this->getTableName())
-            ->where('identifier', $identifier)->first();
+            ->where(['identifier'=> $identifier,'instance'=>$instance])->first();
 
         $storedContent = unserialize($stored->content);
 
@@ -829,14 +833,9 @@ class Cart
      *
      * @return bool
      */
-    private function storedCartWithIdentifierExists($identifier)
+    private function storedCartInstanceWithIdentifierExists($instance, $identifier)
     {
-        $data = ['identifier' => $identifier];
-        if ($this->countInstances() > 1) {
-            $data['instance'] = $this->currentInstance();
-        }
-
-        return $this->getConnection()->table($this->getTableName())->where($data)->exists();
+        return $this->getConnection()->table($this->getTableName())->where(['identifier' => $identifier, 'instance'=> $instance])->exists();
     }
 
     /**

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -98,7 +98,7 @@ class Cart
             $instance = $instance->getInstanceIdentifier();
         }
 
-        $this->instance = 'cart.'.$instance;
+        $this->instance = 'cart.' . $instance;
 
         return $this;
     }
@@ -831,7 +831,11 @@ class Cart
      */
     private function storedCartWithIdentifierExists($identifier)
     {
-        return $this->getConnection()->table($this->getTableName())->where('identifier', $identifier)->where('instance', $this->currentInstance())->exists();
+        $data = ['identifier' => $identifier];
+        if ($this->countInstances() > 1) {
+            $data['instance'] = $this->currentInstance();
+        }
+        return $this->getConnection()->table($this->getTableName())->where($data)->exists();
     }
 
     /**

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -670,7 +670,7 @@ class Cart
         }
 
         $stored = $this->getConnection()->table($this->getTableName())
-            ->where(['identifier'=> $identifier,'instance' => $currentInstance])->first();
+            ->where(['identifier'=> $identifier, 'instance' => $currentInstance])->first();
 
         $storedContent = unserialize(data_get($stored, 'content'));
 
@@ -728,7 +728,7 @@ class Cart
      *
      * @return bool
      */
-    public function merge($identifier, $keepDiscount = false, $keepTax = false, $dispatchAdd = true, $instance = SELF::DEFAULT_INSTANCE)
+    public function merge($identifier, $keepDiscount = false, $keepTax = false, $dispatchAdd = true, $instance = self::DEFAULT_INSTANCE)
     {
         if (!$this->storedCartInstanceWithIdentifierExists($instance, $identifier)) {
             return false;

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -98,7 +98,7 @@ class Cart
             $instance = $instance->getInstanceIdentifier();
         }
 
-        $this->instance = 'cart.' . $instance;
+        $this->instance = 'cart.'.$instance;
 
         return $this;
     }

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -735,7 +735,7 @@ class Cart
         }
 
         $stored = $this->getConnection()->table($this->getTableName())
-            ->where(['identifier'=> $identifier,'instance'=>$instance])->first();
+            ->where(['identifier'=> $identifier, 'instance'=> $instance])->first();
 
         $storedContent = unserialize($stored->content);
 

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -835,6 +835,7 @@ class Cart
         if ($this->countInstances() > 1) {
             $data['instance'] = $this->currentInstance();
         }
+        
         return $this->getConnection()->table($this->getTableName())->where($data)->exists();
     }
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -65,7 +65,7 @@ class CartTest extends TestCase
         parent::setUp();
 
         $this->app->afterResolving('migrator', function ($migrator) {
-            $migrator->path(realpath(__DIR__ . '/../src/Database/migrations'));
+            $migrator->path(realpath(__DIR__.'/../src/Database/migrations'));
         });
     }
 
@@ -1476,8 +1476,6 @@ class CartTest extends TestCase
         $newInstance->add(new BuyableProduct());
         $newInstance->store($newIdentifier = 456);
         $newInstanceSerialized = serialize($newInstance->content());
-
-        $this->assertDatabaseCount('shoppingcart', 2);
 
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1502,8 +1502,8 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct(1, 'first item', 1000), 5);
-        $this->assertEquals("5,000.00", $cart->priceTotal());
-        $this->assertEquals("5,000.0000", $cart->priceTotal(4, ".", ","));
+        $this->assertEquals('5,000.00', $cart->priceTotal());
+        $this->assertEquals('5,000.0000', $cart->priceTotal(4, '.', ','));
     }
 
     /** @test */
@@ -1522,6 +1522,5 @@ class CartTest extends TestCase
         $cart->erase($identifier);
         Event::assertDispatched('cart.erased');
         $this->assertDatabaseMissing('shoppingcart', ['identifier' => $identifier, 'instance' => Cart::DEFAULT_INSTANCE]);
-
     }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -865,11 +865,11 @@ class CartTest extends TestCase
 
         $cart->store($identifier = 123);
 
+        Event::assertDispatched('cart.stored');
+
         $serialized = serialize($cart->content());
 
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
-
-        Event::assertDispatched('cart.stored');
     }
 
     /** @test */
@@ -905,6 +905,8 @@ class CartTest extends TestCase
 
         $cart->store($identifier);
 
+        Event::assertDispatched('cart.stored');
+
         sleep(1);
         $afterSecondStore = Carbon::now();
 
@@ -912,8 +914,6 @@ class CartTest extends TestCase
 
         $this->assertTrue($beforeStore->lessThanOrEqualTo($cart->createdAt()) && $afterStore->greaterThanOrEqualTo($cart->createdAt()));
         $this->assertTrue($beforeSecondStore->lessThanOrEqualTo($cart->updatedAt()) && $afterSecondStore->greaterThanOrEqualTo($cart->updatedAt()));
-
-        Event::assertDispatched('cart.stored');
     }
 
     /**
@@ -936,9 +936,9 @@ class CartTest extends TestCase
 
         $cart->store($identifier = 123);
 
-        $cart->store($identifier);
-
         Event::assertDispatched('cart.stored');
+
+        $cart->store($identifier);
     }
 
     /** @test */
@@ -962,11 +962,11 @@ class CartTest extends TestCase
 
         $cart->restore($identifier);
 
+        Event::assertDispatched('cart.restored');
+
         $this->assertItemsInCart(1, $cart);
 
         $this->assertDatabaseMissing('shoppingcart', ['identifier' => $identifier, 'instance' => 'default']);
-
-        Event::assertDispatched('cart.restored');
     }
 
     /** @test */
@@ -1469,18 +1469,21 @@ class CartTest extends TestCase
 
         $cart->store($identifier = 123);
 
+        Event::assertDispatched('cart.stored');
+
         $serialized = serialize($cart->content());
 
         $newInstance = $this->getCart();
         $newInstance->instance($instanceName = 'someinstance');
         $newInstance->add(new BuyableProduct());
-        $newInstance->store($newIdentifier = 456);
+        $newInstance->store($identifier);
+
+        Event::assertDispatched('cart.stored');
+
         $newInstanceSerialized = serialize($newInstance->content());
 
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
 
-        $this->assertDatabaseHas('shoppingcart', ['identifier' => $newIdentifier, 'instance' => $instanceName, 'content' => $newInstanceSerialized]);
-
-        Event::assertDispatched('cart.stored');
+        $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => $instanceName, 'content' => $newInstanceSerialized]);
     }
 }


### PR DESCRIPTION
This PR checks if there are multiple instances and uses the current instance when checking if storedCartWithIdentifierExists. This fixes #95 