### PR TITLE
Fixing InvalidArgumentException when adding buyable models

### DIFF
--- a/src/CanBeBought.php
+++ b/src/CanBeBought.php
@@ -21,15 +21,15 @@ trait CanBeBought
      */
     public function getBuyableDescription($options = null)
     {
-        if (property_exists($this, 'name')) {
+        if (isset($this->name)) {
             return $this->name;
         }
 
-        if (property_exists($this, 'title')) {
+        if (isset($this->title)) {
             return $this->title;
         }
 
-        if (property_exists($this, 'description')) {
+        if (isset($this->description)) {
             return $this->description;
         }
     }
@@ -41,7 +41,7 @@ trait CanBeBought
      */
     public function getBuyablePrice($options = null)
     {
-        if (property_exists($this, 'price')) {
+        if (isset($this->price)) {
             return $this->price;
         }
     }
@@ -53,7 +53,7 @@ trait CanBeBought
      */
     public function getBuyableWeight($options = null)
     {
-        if (property_exists($this, 'weight')) {
+        if (isset($this->weight)) {
             return $this->weight;
         }
 

--- a/src/CanBeBought.php
+++ b/src/CanBeBought.php
@@ -29,7 +29,7 @@ trait CanBeBought
             return $ttle;
         }
 
-        if (($description = $this->getAttribute('description')) {
+        if (($description = $this->getAttribute('description'))) {
             return $description;
         }
     }

--- a/src/CanBeBought.php
+++ b/src/CanBeBought.php
@@ -21,16 +21,16 @@ trait CanBeBought
      */
     public function getBuyableDescription($options = null)
     {
-        if (isset($this->name)) {
-            return $this->name;
+        if (($name = $this->getAttribute('name'))) {
+            return $name;
         }
 
-        if (isset($this->title)) {
-            return $this->title;
+        if (($title $this->getAttribute('title'))) {
+            return $ttle;
         }
 
-        if (isset($this->description)) {
-            return $this->description;
+        if (($description = $this->getAttribute('description')) {
+            return $description;
         }
     }
 
@@ -41,8 +41,8 @@ trait CanBeBought
      */
     public function getBuyablePrice($options = null)
     {
-        if (isset($this->price)) {
-            return $this->price;
+        if (($price = $this->getAttribute('price'))) {
+            return $price;
         }
     }
 
@@ -53,8 +53,8 @@ trait CanBeBought
      */
     public function getBuyableWeight($options = null)
     {
-        if (isset($this->weight)) {
-            return $this->weight;
+        if (($weight = $this->getAttribute('weight'))) {
+            return $weight;
         }
 
         return 0;

--- a/src/CanBeBought.php
+++ b/src/CanBeBought.php
@@ -25,7 +25,7 @@ trait CanBeBought
             return $name;
         }
 
-        if (($title $this->getAttribute('title'))) {
+        if (($title = $this->getAttribute('title'))) {
             return $ttle;
         }
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -353,7 +353,7 @@ class CartTest extends TestCase
         ]));
 
         $this->assertItemsInCart(1, $cart);
-        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->name);
+        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->description);
 
         Event::assertDispatched('cart.updated');
     }
@@ -373,7 +373,7 @@ class CartTest extends TestCase
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);
 
         $this->assertItemsInCart(1, $cart);
-        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->name);
+        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->description);
 
         Event::assertDispatched('cart.updated');
     }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -83,13 +83,13 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'id' => 1,
-            'name' => 'First item'
+            'id'   => 1,
+            'name' => 'First item',
         ]));
 
         $cart->instance('wishlist')->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Second item'
+            'id'   => 2,
+            'name' => 'Second item',
         ]));
 
         $this->assertItemsInCart(1, $cart->instance(Cart::DEFAULT_INSTANCE));
@@ -133,9 +133,9 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add([new BuyableProduct([
-            'id' => 1
+            'id' => 1,
         ]), new BuyableProduct([
-            'id' => 2
+            'id' => 2,
         ])]);
 
         $this->assertEquals(2, $cart->count());
@@ -151,9 +151,9 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cartItems = $cart->add([new BuyableProduct([
-            'id' => 1
+            'id' => 1,
         ]), new BuyableProduct([
-            'id' => 2
+            'id' => 2,
         ])]);
 
         $this->assertTrue(is_array($cartItems));
@@ -349,7 +349,7 @@ class CartTest extends TestCase
         $cart->add(new BuyableProduct());
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
-            'description' => 'Different description'
+            'description' => 'Different description',
         ]));
 
         $this->assertItemsInCart(1, $cart);
@@ -366,8 +366,8 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => null,
-            'title' => null
+            'name'  => null,
+            'title' => null,
         ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);
@@ -390,7 +390,7 @@ class CartTest extends TestCase
         $cart->add(new BuyableProduct());
 
         $cart->update('none-existing-rowid', new BuyableProduct([
-            'description' => 'Different description'
+            'description' => 'Different description',
         ]));
     }
 
@@ -588,12 +588,12 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'First item'
+            'name' => 'First item',
         ]));
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Second item',
-            'price' => 25.00
+            'id'    => 2,
+            'name'  => 'Second item',
+            'price' => 25.00,
         ]), 2);
 
         $this->assertItemsInCart(3, $cart);
@@ -606,13 +606,13 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'First item', 
-            'price' => 1000.00
+            'name'  => 'First item',
+            'price' => 1000.00,
         ]));
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Second item',
-            'price' => 2500.00
+            'id'    => 2,
+            'name'  => 'Second item',
+            'price' => 2500.00,
         ]), 2);
 
         $this->assertItemsInCart(3, $cart);
@@ -628,7 +628,7 @@ class CartTest extends TestCase
             'name' => 'Some item',
         ]));
         $cart->add(new BuyableProduct([
-            'id' => 2,
+            'id'   => 2,
             'name' => 'Another item',
         ]));
 
@@ -648,15 +648,15 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some item'
+            'name' => 'Some item',
         ]));
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Some item'
+            'id'   => 2,
+            'name' => 'Some item',
         ]));
         $cart->add(new BuyableProduct([
-            'id' => 3,
-            'name' => 'Another item'
+            'id'   => 3,
+            'name' => 'Another item',
         ]));
 
         $cartItem = $cart->search(function ($cartItem, $rowId) {
@@ -672,11 +672,11 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some item'
+            'name' => 'Some item',
         ]), 1, ['color' => 'red']);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Another item'
+            'id'   => 2,
+            'name' => 'Another item',
         ]), 1, ['color' => 'blue']);
 
         $cartItem = $cart->search(function ($cartItem, $rowId) {
@@ -751,7 +751,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title',
+            'name'  => 'Some title',
             'price' => 9.99,
         ]), 3);
 
@@ -766,7 +766,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title',
+            'name'  => 'Some title',
             'price' => 500,
         ]), 3);
 
@@ -781,7 +781,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title'
+            'name' => 'Some title',
         ]), 1);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -795,7 +795,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title'
+            'name' => 'Some title',
         ]), 1);
 
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
@@ -811,7 +811,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title',
+            'name'  => 'Some title',
             'price' => 10000.00,
         ]), 1);
 
@@ -826,12 +826,12 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title'
+            'name' => 'Some title',
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Some title',
-            'price' => 20.00
+            'id'    => 2,
+            'name'  => 'Some title',
+            'price' => 20.00,
         ]), 2);
 
         $this->assertEquals(10.50, $cart->tax);
@@ -843,13 +843,13 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title', 
-            'price' => 1000.00
+            'name'  => 'Some title',
+            'price' => 1000.00,
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Some title', 
-            'price' => 2000.00
+            'id'    => 2,
+            'name'  => 'Some title',
+            'price' => 2000.00,
         ]), 2);
 
         $this->assertEquals('1.050,00', $cart->tax(2, ',', '.'));
@@ -861,7 +861,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title'
+            'name' => 'Some title',
         ]), 1);
 
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
@@ -878,8 +878,8 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct(), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'price' => 20.00
+            'id'    => 2,
+            'price' => 20.00,
         ]), 2);
 
         $this->assertEquals(50.00, $cart->subtotal);
@@ -891,11 +891,11 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'price' => 1000.00
+            'price' => 1000.00,
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2, 
-            'price' => 2000.00
+            'id'    => 2,
+            'price' => 2000.00,
         ]), 2);
 
         $this->assertEquals('5000,00', $cart->subtotal(2, ',', ''));
@@ -909,11 +909,11 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'price' => 1000.00
+            'price' => 1000.00,
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' =>2,
-            'price' => 2000.00
+            'id'    => 2,
+            'price' => 2000.00,
         ]), 2);
 
         $this->assertEquals('5000,00', $cart->subtotal());
@@ -933,7 +933,7 @@ class CartTest extends TestCase
         $cart = $this->getCartDiscount(50);
 
         $cart->add(new BuyableProduct([
-            'price' => 2000.00
+            'price' => 2000.00,
         ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1111,7 +1111,7 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 1);
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['qty' => 2]);
@@ -1136,12 +1136,12 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'First item',
-            'price' => 5.00
+            'name'  => 'First item',
+            'price' => 5.00,
         ]), 2);
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
-            'name' => 'First item', 
+            'name' => 'First item',
         ]));
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1179,7 +1179,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 2);
 
         $cart->setGlobalTax(0);
@@ -1195,7 +1195,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 2);
 
         $cart->setGlobalTax(0);
@@ -1212,8 +1212,8 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Item',
-            'price' => 10.004
+            'name'  => 'Item',
+            'price' => 10.004,
         ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1232,11 +1232,11 @@ class CartTest extends TestCase
 
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Item 2'
+            'id'   => 2,
+            'name' => 'Item 2',
         ]), 1);
         $cart->store('test');
 
@@ -1266,16 +1266,16 @@ class CartTest extends TestCase
     public function it_cant_merge_non_existing_cart()
     {
         $this->artisan('migrate', [
-            '--database' => 'testing'
+            '--database' => 'testing',
         ]);
         Event::fake();
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Item 2'
+            'id'   => 2,
+            'name' => 'Item 2',
         ]), 1);
         $this->assertEquals(false, $cart->merge('doesNotExist'));
         $this->assertEquals(2, $cart->countItems());
@@ -1286,7 +1286,7 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
@@ -1307,7 +1307,7 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $this->assertEquals(50, $cartItem->discountRate);
@@ -1318,7 +1318,7 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $this->assertEquals(null, $cartItem->doesNotExist);
@@ -1330,7 +1330,7 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
         $cart->add(new BuyableProduct([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $cart->setDiscount('027c91341fd5cf4d2579b49c4b6a90da', 50);
@@ -1342,7 +1342,7 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
         $cart->add(new BuyableProduct([
-            'name' => 'First item',
+            'name'   => 'First item',
             'weight' => 250,
         ]), 2);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1357,7 +1357,7 @@ class CartTest extends TestCase
     public function cart_can_create_and_restore_from_instance_identifier()
     {
         $this->artisan('migrate', [
-            '--database' => 'testing'
+            '--database' => 'testing',
         ]);
 
         Event::fake();
@@ -1369,7 +1369,7 @@ class CartTest extends TestCase
         $this->assertEquals('User1', $cart->currentInstance());
 
         $cart->add(new BuyableProduct([
-            'name' => 'First item',
+            'name'   => 'First item',
             'weight' => 250,
         ]), 2);
         $this->assertItemsInCart(2, $cart);
@@ -1388,7 +1388,7 @@ class CartTest extends TestCase
         $cart = $this->getCartDiscount(50);
 
         $cart->add(new BuyableProductTrait([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1413,7 +1413,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProductTrait([
-            'name' => 'First item'
+            'name' => 'First item',
         ]), 0.5);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1443,16 +1443,16 @@ class CartTest extends TestCase
     public function it_can_merge_without_dispatching_add_events()
     {
         $this->artisan('migrate', [
-            '--database' => 'testing'
+            '--database' => 'testing',
         ]);
 
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Item 2'
+            'id'   => 2,
+            'name' => 'Item 2',
         ]), 1);
         $cart->store('test');
 
@@ -1483,11 +1483,11 @@ class CartTest extends TestCase
 
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Item 2'
+            'id'   => 2,
+            'name' => 'Item 2',
         ]), 1);
         $cart->store('test');
 
@@ -1516,18 +1516,18 @@ class CartTest extends TestCase
         $cart = $this->getCartDiscount(6);
 
         $cartItem = $cart->add(new BuyableProduct([
-            'name' => 'First item',
-            'price' => 0.18929
+            'name'  => 'First item',
+            'price' => 0.18929,
         ]), 1000);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Second item', 
-            'price' => 4.41632
+            'id'    => 2,
+            'name'  => 'Second item',
+            'price' => 4.41632,
         ]), 5);
         $cart->add(new BuyableProduct([
-            'id' => 3,
-            'name' => 'Third item',
-            'price' => 0.37995
+            'id'    => 3,
+            'name'  => 'Third item',
+            'price' => 0.37995,
         ]), 25);
 
         $cart->setGlobalTax(22);
@@ -1546,8 +1546,8 @@ class CartTest extends TestCase
         config(['cart.calculator' => GrossPrice::class]);
 
         $cartItem = $cart->add(new BuyableProduct([
-            'name' => 'First item',
-            'price' => 100
+            'name'  => 'First item',
+            'price' => 100,
         ]), 2);
 
         $cart->setGlobalTax(22);
@@ -1565,18 +1565,18 @@ class CartTest extends TestCase
         $cart = $this->getCartDiscount(6);
 
         $cartItem = $cart->add(new BuyableProduct([
-            'name' => 'First item', 
-            'price' => 0.23093
+            'name'  => 'First item',
+            'price' => 0.23093,
         ]), 1000);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Second item',
-            'price' => 5.38791
+            'id'    => 2,
+            'name'  => 'Second item',
+            'price' => 5.38791,
         ]), 5);
         $cart->add(new BuyableProduct([
-            'id' => 3,
-            'name' => 'Third item',
-            'price' => 0.46354
+            'id'    => 3,
+            'name'  => 'Third item',
+            'price' => 0.46354,
         ]), 25);
 
         $cart->setGlobalTax(22);
@@ -1671,8 +1671,8 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'first item',
-            'price' => 1000
+            'name'  => 'first item',
+            'price' => 1000,
         ]), $qty = 5);
         $this->assertEquals(5000, $cart->priceTotalFloat());
     }
@@ -1683,8 +1683,8 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'first item',
-            'price' => 1000
+            'name'  => 'first item',
+            'price' => 1000,
         ]), 5);
         $this->assertEquals('5,000.00', $cart->priceTotal());
         $this->assertEquals('5,000.0000', $cart->priceTotal(4, '.', ','));
@@ -1701,11 +1701,11 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
         ]), 1);
         $cart->add(new BuyableProduct([
-            'id' => 2,
-            'name' => 'Item 2'
+            'id'   => 2,
+            'name' => 'Item 2',
         ]), 1);
         $cart->store($identifier = 'test');
         $cart->erase($identifier);

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -346,7 +346,7 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct([
+        $cart->add(new BuyableProductTrait([
             'description' => 'Description',
         ]));
 
@@ -355,7 +355,7 @@ class CartTest extends TestCase
         ]));
 
         $this->assertItemsInCart(1, $cart);
-        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->description);
+        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->name);
 
         Event::assertDispatched('cart.updated');
     }
@@ -367,14 +367,14 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct([
+        $cart->add(new BuyableProductTrait([
             'description' => 'Description',
         ]));
 
-        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);
+        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['name' => 'Different description']);
 
         $this->assertItemsInCart(1, $cart);
-        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->description);
+        $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->name);
 
         Event::assertDispatched('cart.updated');
     }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -132,7 +132,9 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add([new BuyableProduct(1), new BuyableProduct([
+        $cart->add([new BuyableProduct([
+            'id' => 1
+        ]), new BuyableProduct([
             'id' => 2
         ])]);
 
@@ -148,7 +150,9 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cartItems = $cart->add([new BuyableProduct(1), new BuyableProduct([
+        $cartItems = $cart->add([new BuyableProduct([
+            'id' => 1
+        ]), new BuyableProduct([
             'id' => 2
         ])]);
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1203,7 +1203,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Item'
+            'name' => 'Item',
             'price' 10.004,
         ]), 2);
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -759,7 +759,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name' => 'Some title'
+            'name' => 'Some title',
             'price' => 500,
         ]), 3);
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1204,7 +1204,7 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct([
             'name' => 'Item',
-            'price' 10.004,
+            'price' => 10.004
         ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1223,11 +1223,11 @@ class CartTest extends TestCase
 
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'Item',
+            'name' => 'Item'
         ]), 1);
         $cart->add(new BuyableProduct([
             'id' => 2,
-            'name' => 'Item 2',
+            'name' => 'Item 2'
         ]), 1);
         $cart->store('test');
 
@@ -1257,16 +1257,16 @@ class CartTest extends TestCase
     public function it_cant_merge_non_existing_cart()
     {
         $this->artisan('migrate', [
-            '--database' => 'testing',
+            '--database' => 'testing'
         ]);
         Event::fake();
         $cart = $this->getCartDiscount(50);
         $cart->add(new BuyableProduct([
-            'name' => 'Item',
+            'name' => 'Item'
         ]), 1);
         $cart->add(new BuyableProduct([
             'id' => 2,
-            'name' => 'Item 2',
+            'name' => 'Item 2'
         ]), 1);
         $this->assertEquals(false, $cart->merge('doesNotExist'));
         $this->assertEquals(2, $cart->countItems());
@@ -1348,7 +1348,7 @@ class CartTest extends TestCase
     public function cart_can_create_and_restore_from_instance_identifier()
     {
         $this->artisan('migrate', [
-            '--database' => 'testing',
+            '--database' => 'testing'
         ]);
 
         Event::fake();
@@ -1379,7 +1379,7 @@ class CartTest extends TestCase
         $cart = $this->getCartDiscount(50);
 
         $cart->add(new BuyableProductTrait([
-            'name' => 'First item',
+            'name' => 'First item'
         ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1404,7 +1404,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProductTrait([
-            'name' => 'First item',
+            'name' => 'First item'
         ]), 0.5);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
@@ -1434,7 +1434,7 @@ class CartTest extends TestCase
     public function it_can_merge_without_dispatching_add_events()
     {
         $this->artisan('migrate', [
-            '--database' => 'testing',
+            '--database' => 'testing'
         ]);
 
         $cart = $this->getCartDiscount(50);

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -82,9 +82,15 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'First item'));
+        $cart->add(new BuyableProduct([
+            'id' => 1,
+            'name' => 'First item'
+        ]));
 
-        $cart->instance('wishlist')->add(new BuyableProduct(2, 'Second item'));
+        $cart->instance('wishlist')->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Second item'
+        ]));
 
         $this->assertItemsInCart(1, $cart->instance(Cart::DEFAULT_INSTANCE));
         $this->assertItemsInCart(1, $cart->instance('wishlist'));
@@ -126,7 +132,9 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add([new BuyableProduct(1), new BuyableProduct(2)]);
+        $cart->add([new BuyableProduct(1), new BuyableProduct([
+            'id' => 2
+        ])]);
 
         $this->assertEquals(2, $cart->count());
 
@@ -140,7 +148,9 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cartItems = $cart->add([new BuyableProduct(1), new BuyableProduct(2)]);
+        $cartItems = $cart->add([new BuyableProduct(1), new BuyableProduct([
+            'id' => 2
+        ])]);
 
         $this->assertTrue(is_array($cartItems));
         $this->assertCount(2, $cartItems);
@@ -334,7 +344,9 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct());
 
-        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct(1, 'Different description'));
+        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
+            'description' => 'Different description'
+        ]));
 
         $this->assertItemsInCart(1, $cart);
         $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->name);
@@ -351,7 +363,7 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct());
 
-        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['name' => 'Different description']);
+        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);
 
         $this->assertItemsInCart(1, $cart);
         $this->assertEquals('Different description', $cart->get('027c91341fd5cf4d2579b49c4b6a90da')->name);
@@ -370,7 +382,9 @@ class CartTest extends TestCase
 
         $cart->add(new BuyableProduct());
 
-        $cart->update('none-existing-rowid', new BuyableProduct(1, 'Different description'));
+        $cart->update('none-existing-rowid', new BuyableProduct([
+            'description' => 'Different description'
+        ]));
     }
 
     /** @test */
@@ -484,8 +498,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1));
-        $cart->add(new BuyableProduct(2));
+        $cart->add(new BuyableProduct());
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+        ]));
 
         $content = $cart->content();
 
@@ -509,8 +525,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1));
-        $cart->add(new BuyableProduct(2));
+        $cart->add(new BuyableProduct());
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+        ]));
 
         $content = $cart->content();
 
@@ -562,8 +580,14 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'First item', 10.00));
-        $cart->add(new BuyableProduct(2, 'Second item', 25.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item'
+        ]));
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Second item',
+            'price' => 25.00
+        ]), 2);
 
         $this->assertItemsInCart(3, $cart);
         $this->assertEquals(60.00, $cart->subtotal());
@@ -574,8 +598,15 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'First item', 1000.00));
-        $cart->add(new BuyableProduct(2, 'Second item', 2500.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item', 
+            'price' => 1000.00
+        ]));
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Second item',
+            'price' => 2500.00
+        ]), 2);
 
         $this->assertItemsInCart(3, $cart);
         $this->assertEquals('6.000,00', $cart->subtotal(2, ',', '.'));
@@ -586,8 +617,13 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some item'));
-        $cart->add(new BuyableProduct(2, 'Another item'));
+        $cart->add(new BuyableProduct([
+            'name' => 'Some item',
+        ]));
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Another item',
+        ]));
 
         $cartItem = $cart->search(function ($cartItem, $rowId) {
             return $cartItem->name == 'Some item';
@@ -604,9 +640,17 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some item'));
-        $cart->add(new BuyableProduct(2, 'Some item'));
-        $cart->add(new BuyableProduct(3, 'Another item'));
+        $cart->add(new BuyableProduct([
+            'name' => 'Some item'
+        ]));
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Some item'
+        ]));
+        $cart->add(new BuyableProduct([
+            'id' => 3,
+            'name' => 'Another item'
+        ]));
 
         $cartItem = $cart->search(function ($cartItem, $rowId) {
             return $cartItem->name == 'Some item';
@@ -620,8 +664,13 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some item'), 1, ['color' => 'red']);
-        $cart->add(new BuyableProduct(2, 'Another item'), 1, ['color' => 'blue']);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some item'
+        ]), 1, ['color' => 'red']);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Another item'
+        ]), 1, ['color' => 'blue']);
 
         $cartItem = $cart->search(function ($cartItem, $rowId) {
             return $cartItem->options->color == 'red';
@@ -694,7 +743,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 9.99), 3);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title',
+            'price' => 9.99,
+        ]), 3);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -706,7 +758,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 500), 3);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title'
+            'price' => 500,
+        ]), 3);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -718,7 +773,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title'
+        ]), 1);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -730,7 +787,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title'
+        ]), 1);
 
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
 
@@ -744,7 +803,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 10000.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title',
+            'price' => 10000.00,
+        ]), 1);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -756,8 +818,14 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Some title', 20.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title'
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Some title',
+            'price' => 20.00
+        ]), 2);
 
         $this->assertEquals(10.50, $cart->tax);
     }
@@ -767,8 +835,15 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 1000.00), 1);
-        $cart->add(new BuyableProduct(2, 'Some title', 2000.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title', 
+            'price' => 1000.00
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Some title', 
+            'price' => 2000.00
+        ]), 2);
 
         $this->assertEquals('1.050,00', $cart->tax(2, ',', '.'));
     }
@@ -778,7 +853,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Some title'
+        ]), 1);
 
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
 
@@ -792,8 +869,11 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Some title', 20.00), 2);
+        $cart->add(new BuyableProduct(), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'price' => 20.00
+        ]), 2);
 
         $this->assertEquals(50.00, $cart->subtotal);
     }
@@ -803,8 +883,13 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 1000.00), 1);
-        $cart->add(new BuyableProduct(2, 'Some title', 2000.00), 2);
+        $cart->add(new BuyableProduct([
+            'price' => 1000.00
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2, 
+            'price' => 2000.00
+        ]), 2);
 
         $this->assertEquals('5000,00', $cart->subtotal(2, ',', ''));
     }
@@ -816,8 +901,13 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Some title', 1000.00), 1);
-        $cart->add(new BuyableProduct(2, 'Some title', 2000.00), 2);
+        $cart->add(new BuyableProduct([
+            'price' => 1000.00
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' =>2,
+            'price' => 2000.00
+        ]), 2);
 
         $this->assertEquals('5000,00', $cart->subtotal());
         $this->assertEquals('1050,00', $cart->tax());
@@ -835,7 +925,9 @@ class CartTest extends TestCase
 
         $cart = $this->getCartDiscount(50);
 
-        $cart->add(new BuyableProduct(1, 'Some title', 2000.00), 2);
+        $cart->add(new BuyableProduct([
+            'price' => 2000.00
+        ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -988,7 +1080,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
 
-        $cart->add(new BuyableProduct(1, 'First item', 10.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item',
+        ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -1032,9 +1126,14 @@ class CartTest extends TestCase
     public function it_can_calculate_all_values_after_updating_from_buyable()
     {
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'First item', 5.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item',
+            'price' => 5.00
+        ]), 2);
 
-        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct(1, 'First item', 10.00));
+        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
+            'name' => 'First item', 
+        ]));
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -1070,7 +1169,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item'
+        ]), 2);
 
         $cart->setGlobalTax(0);
 
@@ -1084,7 +1185,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item'
+        ]), 2);
 
         $cart->setGlobalTax(0);
         $cart->setGlobalDiscount(50);
@@ -1099,7 +1202,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'Item', 10.004), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item'
+            'price' 10.004,
+        ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -1116,8 +1222,13 @@ class CartTest extends TestCase
         Event::fake();
 
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Item 2', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item',
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Item 2',
+        ]), 1);
         $cart->store('test');
 
         $cart2 = $this->getCart();
@@ -1150,8 +1261,13 @@ class CartTest extends TestCase
         ]);
         Event::fake();
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Item 2', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item',
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Item 2',
+        ]), 1);
         $this->assertEquals(false, $cart->merge('doesNotExist'));
         $this->assertEquals(2, $cart->countItems());
     }
@@ -1160,7 +1276,9 @@ class CartTest extends TestCase
     public function cart_can_calculate_all_values()
     {
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'First item', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item'
+        ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
         $this->assertEquals('10.00', $cart->initial(2));
@@ -1179,7 +1297,9 @@ class CartTest extends TestCase
     public function can_access_cart_item_propertys()
     {
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'First item', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item'
+        ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $this->assertEquals(50, $cartItem->discountRate);
     }
@@ -1188,7 +1308,9 @@ class CartTest extends TestCase
     public function cant_access_non_existant_propertys()
     {
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'First item', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item'
+        ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $this->assertEquals(null, $cartItem->doesNotExist);
         $this->assertEquals(null, $cart->doesNotExist);
@@ -1198,7 +1320,9 @@ class CartTest extends TestCase
     public function can_set_cart_item_discount()
     {
         $cart = $this->getCart();
-        $cart->add(new BuyableProduct(1, 'First item', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item'
+        ]), 1);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $cart->setDiscount('027c91341fd5cf4d2579b49c4b6a90da', 50);
         $this->assertEquals(50, $cartItem->discountRate);
@@ -1208,7 +1332,10 @@ class CartTest extends TestCase
     public function can_set_cart_item_weight_and_calculate_total_weight()
     {
         $cart = $this->getCart();
-        $cart->add(new BuyableProduct(1, 'First item', 10.00, 250), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item',
+            'weight' => 250,
+        ]), 2);
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
         $cart->setDiscount('027c91341fd5cf4d2579b49c4b6a90da', 50);
         $this->assertEquals('500.00', $cart->weight(2));
@@ -1232,7 +1359,10 @@ class CartTest extends TestCase
         $cart->instance($identifier);
         $this->assertEquals('User1', $cart->currentInstance());
 
-        $cart->add(new BuyableProduct(1, 'First item', 10.00, 250), 2);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item',
+            'weight' => 250,
+        ]), 2);
         $this->assertItemsInCart(2, $cart);
 
         $cart->store($identifier);
@@ -1248,7 +1378,9 @@ class CartTest extends TestCase
     {
         $cart = $this->getCartDiscount(50);
 
-        $cart->add(new BuyableProductTrait(1, 'First item', 10.00), 2);
+        $cart->add(new BuyableProductTrait([
+            'name' => 'First item',
+        ]), 2);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -1271,7 +1403,9 @@ class CartTest extends TestCase
         // https://github.com/Crinsane/LaravelShoppingcart/issues/544
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProductTrait(1, 'First item', 10.00), 0.5);
+        $cart->add(new BuyableProductTrait([
+            'name' => 'First item',
+        ]), 0.5);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
@@ -1304,8 +1438,13 @@ class CartTest extends TestCase
         ]);
 
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Item 2', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item'
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Item 2'
+        ]), 1);
         $cart->store('test');
 
         Event::fakeFor(function () {
@@ -1334,8 +1473,13 @@ class CartTest extends TestCase
         ]);
 
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Item 2', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item'
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Item 2'
+        ]), 1);
         $cart->store('test');
 
         Event::fakeFor(function () {
@@ -1362,9 +1506,20 @@ class CartTest extends TestCase
 
         $cart = $this->getCartDiscount(6);
 
-        $cartItem = $cart->add(new BuyableProduct(1, 'First item', 0.18929), 1000);
-        $cart->add(new BuyableProduct(2, 'Second item', 4.41632), 5);
-        $cart->add(new BuyableProduct(3, 'Third item', 0.37995), 25);
+        $cartItem = $cart->add(new BuyableProduct([
+            'name' => 'First item',
+            'price' => 0.18929
+        ]), 1000);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Second item', 
+            'price' => 4.41632
+        ]), 5);
+        $cart->add(new BuyableProduct([
+            'id' => 3,
+            'name' => 'Third item',
+            'price' => 0.37995
+        ]), 25);
 
         $cart->setGlobalTax(22);
 
@@ -1381,7 +1536,10 @@ class CartTest extends TestCase
         $cart = $this->getCartDiscount(0);
         config(['cart.calculator' => GrossPrice::class]);
 
-        $cartItem = $cart->add(new BuyableProduct(1, 'First item', 100), 2);
+        $cartItem = $cart->add(new BuyableProduct([
+            'name' => 'First item',
+            'price' => 100
+        ]), 2);
 
         $cart->setGlobalTax(22);
 
@@ -1397,9 +1555,20 @@ class CartTest extends TestCase
 
         $cart = $this->getCartDiscount(6);
 
-        $cartItem = $cart->add(new BuyableProduct(1, 'First item', 0.23093), 1000);
-        $cart->add(new BuyableProduct(2, 'Second item', 5.38791), 5);
-        $cart->add(new BuyableProduct(3, 'Third item', 0.46354), 25);
+        $cartItem = $cart->add(new BuyableProduct([
+            'name' => 'First item', 
+            'price' => 0.23093
+        ]), 1000);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Second item',
+            'price' => 5.38791
+        ]), 5);
+        $cart->add(new BuyableProduct([
+            'id' => 3,
+            'name' => 'Third item',
+            'price' => 0.46354
+        ]), 25);
 
         $cart->setGlobalTax(22);
 
@@ -1492,7 +1661,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'first item', $price = 1000), $qty = 5);
+        $cart->add(new BuyableProduct([
+            'name' => 'first item',
+            'price' => 1000
+        ]), $qty = 5);
         $this->assertEquals(5000, $cart->priceTotalFloat());
     }
 
@@ -1501,7 +1673,10 @@ class CartTest extends TestCase
     {
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct(1, 'first item', 1000), 5);
+        $cart->add(new BuyableProduct([
+            'name' => 'first item',
+            'price' => 1000
+        ]), 5);
         $this->assertEquals('5,000.00', $cart->priceTotal());
         $this->assertEquals('5,000.0000', $cart->priceTotal(4, '.', ','));
     }
@@ -1516,8 +1691,13 @@ class CartTest extends TestCase
         Event::fake();
 
         $cart = $this->getCart();
-        $cart->add(new BuyableProduct(1, 'Item', 10.00), 1);
-        $cart->add(new BuyableProduct(2, 'Item 2', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'Item'
+        ]), 1);
+        $cart->add(new BuyableProduct([
+            'id' => 2,
+            'name' => 'Item 2'
+        ]), 1);
         $cart->store($identifier = 'test');
         $cart->erase($identifier);
         Event::assertDispatched('cart.erased');

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -347,7 +347,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'description' => 'Description'
+            'description' => 'Description',
         ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
@@ -368,7 +368,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'description' => 'Description'
+            'description' => 'Description',
         ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -350,7 +350,8 @@ class CartTest extends TestCase
             'description' => 'Description',
         ]));
 
-        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
+        $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProductTrait([
+            'name' => '',
             'description' => 'Different description',
         ]));
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -346,7 +346,9 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct());
+        $cart->add(new BuyableProduct([
+            'description' => 'Description'
+        ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProduct([
             'description' => 'Different description',
@@ -366,8 +368,7 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name'  => '',
-            'title' => '',
+            'description' => 'Description'
         ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -351,7 +351,7 @@ class CartTest extends TestCase
         ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', new BuyableProductTrait([
-            'name' => '',
+            'name'        => '',
             'description' => 'Different description',
         ]));
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -366,8 +366,8 @@ class CartTest extends TestCase
         $cart = $this->getCart();
 
         $cart->add(new BuyableProduct([
-            'name'  => null,
-            'title' => null,
+            'name'  => '',
+            'title' => '',
         ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1107,7 +1107,9 @@ class CartTest extends TestCase
     public function it_can_calculate_all_values_after_updating_from_array()
     {
         $cart = $this->getCartDiscount(50);
-        $cart->add(new BuyableProduct(1, 'First item', 10.00), 1);
+        $cart->add(new BuyableProduct([
+            'name' => 'First item'
+        ]), 1);
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['qty' => 2]);
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -365,7 +365,10 @@ class CartTest extends TestCase
 
         $cart = $this->getCart();
 
-        $cart->add(new BuyableProduct());
+        $cart->add(new BuyableProduct([
+            'name' => null,
+            'title' => null
+        ));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -368,7 +368,7 @@ class CartTest extends TestCase
         $cart->add(new BuyableProduct([
             'name' => null,
             'title' => null
-        ));
+        ]));
 
         $cart->update('027c91341fd5cf4d2579b49c4b6a90da', ['description' => 'Different description']);
 

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -18,9 +18,9 @@ class BuyableProduct extends Model implements Buyable
         'title',
         'description',
         'price',
-        'weight'
+        'weight',
     ];
-    
+
     protected $attributes = [
         'id'     => 1,
         'name'   => 'Item name',

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -3,8 +3,9 @@
 namespace Gloudemans\Tests\Shoppingcart\Fixtures;
 
 use Gloudemans\Shoppingcart\Contracts\Buyable;
+use Illuminate\Database\Eloquent\Model;
 
-class BuyableProduct implements Buyable
+class BuyableProduct extends Model implements Buyable
 {
     /**
      * @var int|string

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -7,6 +7,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class BuyableProduct extends Model implements Buyable
 {
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'name',
+        'price',
+        'weight'
+    ];
+    
     protected $attributes = [
         'id'     => 1,
         'name'   => 'Item name',

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -8,41 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class BuyableProduct extends Model implements Buyable
 {
     /**
-     * @var int|string
-     */
-    private $id;
-
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var float
-     */
-    private $price;
-
-    /**
-     * @var float
-     */
-    private $weight;
-
-    /**
-     * BuyableProduct constructor.
-     *
-     * @param int|string $id
-     * @param string     $name
-     * @param float      $price
-     */
-    public function __construct($id = 1, $name = 'Item name', $price = 10.00, $weight = 0)
-    {
-        $this->id = $id;
-        $this->name = $name;
-        $this->price = $price;
-        $this->weight = $weight;
-    }
-
-    /**
      * Get the identifier of the Buyable item.
      *
      * @return int|string

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -15,6 +15,8 @@ class BuyableProduct extends Model implements Buyable
     protected $fillable = [
         'id',
         'name',
+        'title',
+        'description',
         'price',
         'weight'
     ];

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -8,9 +8,9 @@ use Illuminate\Database\Eloquent\Model;
 class BuyableProduct extends Model implements Buyable
 {
     protected $attributes = [
-        'id'  => 1,
-        'name' => 'Item name',
-        'price' => 10.00,
+        'id'     => 1,
+        'name'   => 'Item name',
+        'price'  => 10.00,
         'weight' => 0,
     ];
     

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -27,7 +27,7 @@ class BuyableProduct extends Model implements Buyable
         'price'  => 10.00,
         'weight' => 0,
     ];
-    
+
     /**
      * Get the identifier of the Buyable item.
      *

--- a/tests/Fixtures/BuyableProduct.php
+++ b/tests/Fixtures/BuyableProduct.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class BuyableProduct extends Model implements Buyable
 {
+    protected $attributes = [
+        'id'  => 1,
+        'name' => 'Item name',
+        'price' => 10.00,
+        'weight' => 0,
+    ];
+    
     /**
      * Get the identifier of the Buyable item.
      *

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -8,4 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 class BuyableProductTrait extends Model implements Buyable
 {
     use \Gloudemans\Shoppingcart\CanBeBought;
+    
+    protected $attributes = [
+        'id'  => 1,
+        'name' => 'Item name',
+        'price' => 10.00,
+        'weight' => 0,
+    ];
 }

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -17,6 +17,8 @@ class BuyableProductTrait extends Model implements Buyable
     protected $fillable = [
         'id',
         'name',
+        'title',
+        'description',
         'price',
         'weight'
     ];

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -22,7 +22,7 @@ class BuyableProductTrait extends Model implements Buyable
         'price',
         'weight'
     ];
-    
+
     protected $attributes = [
         'id'     => 1,
         'name'   => 'Item name',

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class BuyableProductTrait extends Model implements Buyable
 {
     use \Gloudemans\Shoppingcart\CanBeBought;
-    
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -9,6 +9,18 @@ class BuyableProductTrait extends Model implements Buyable
 {
     use \Gloudemans\Shoppingcart\CanBeBought;
     
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'name',
+        'price',
+        'weight'
+    ];
+    
     protected $attributes = [
         'id'     => 1,
         'name'   => 'Item name',

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -3,8 +3,9 @@
 namespace Gloudemans\Tests\Shoppingcart\Fixtures;
 
 use Gloudemans\Shoppingcart\Contracts\Buyable;
+use Illuminate\Database\Eloquent\Model;
 
-class BuyableProductTrait implements Buyable
+class BuyableProductTrait extends Model implements Buyable
 {
     use \Gloudemans\Shoppingcart\CanBeBought;
 

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -20,7 +20,7 @@ class BuyableProductTrait extends Model implements Buyable
         'title',
         'description',
         'price',
-        'weight'
+        'weight',
     ];
 
     protected $attributes = [

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -8,39 +8,4 @@ use Illuminate\Database\Eloquent\Model;
 class BuyableProductTrait extends Model implements Buyable
 {
     use \Gloudemans\Shoppingcart\CanBeBought;
-
-    /**
-     * @var int|string
-     */
-    private $id;
-
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var float
-     */
-    private $price;
-
-    /**
-     * @var float
-     */
-    private $weight;
-
-    /**
-     * BuyableProduct constructor.
-     *
-     * @param int|string $id
-     * @param string     $name
-     * @param float      $price
-     */
-    public function __construct($id = 1, $name = 'Item name', $price = 10.00, $weight = 0)
-    {
-        $this->id = $id;
-        $this->name = $name;
-        $this->price = $price;
-        $this->weight = $weight;
-    }
 }

--- a/tests/Fixtures/BuyableProductTrait.php
+++ b/tests/Fixtures/BuyableProductTrait.php
@@ -10,9 +10,9 @@ class BuyableProductTrait extends Model implements Buyable
     use \Gloudemans\Shoppingcart\CanBeBought;
     
     protected $attributes = [
-        'id'  => 1,
-        'name' => 'Item name',
-        'price' => 10.00,
+        'id'     => 1,
+        'name'   => 'Item name',
+        'price'  => 10.00,
         'weight' => 0,
     ];
 }


### PR DESCRIPTION
Fixing InvalidArgumentException when adding buyable models on newer Laravel Versions.
PHP's property_exists always returns false in this case, so the cart is not populated with model attributes.