### PR TITLE
Use base64 to avoid truncation with PostgreSQL

### DIFF
--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -968,7 +968,11 @@ class CartTest extends TestCase
 
         Event::assertDispatched('cart.stored');
 
-        $serialized = serialize($cart->content());
+        if (app('db')->getDriverName() === 'pgsql') {
+            $serialized = base64_encode(serialize($cart->content()));
+        } else {
+            $serialized = serialize($cart->content());
+        }
 
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
     }
@@ -1651,7 +1655,11 @@ class CartTest extends TestCase
 
         Event::assertDispatched('cart.stored');
 
-        $serialized = serialize($cart->content());
+        if (app('db')->getDriverName() === 'pgsql') {
+            $serialized = base64_encode(serialize($cart->content()));
+        } else {
+            $serialized = serialize($cart->content());
+        }
 
         $newInstance = $this->getCart();
         $newInstance->instance($instanceName = 'someinstance');
@@ -1660,7 +1668,11 @@ class CartTest extends TestCase
 
         Event::assertDispatched('cart.stored');
 
-        $newInstanceSerialized = serialize($newInstance->content());
+        if (app('db')->getDriverName() === 'pgsql') {
+            $newInstanceSerialized = base64_encode(serialize($newInstance->content()));
+        } else {
+            $newInstanceSerialized = serialize($newInstance->content());
+        }
 
         $this->assertDatabaseHas('shoppingcart', ['identifier' => $identifier, 'instance' => Cart::DEFAULT_INSTANCE, 'content' => $serialized]);
 


### PR DESCRIPTION
When using a PostgreSQL database, serializing the cart's content and storing them in a text column doesn't work. because [PostegreSQL drops everything after a zero byte in text columns](https://www.postgresql.org/docs/8.3/libpq-exec.html#LIBPQ-EXEC-ESCAPE-STRING). And seeing as [PHP's serialize adds zero bytes to private and protected members](https://www.php.net/manual/en/function.serialize) 
![image](https://user-images.githubusercontent.com/12043163/167033134-58d521d7-88ea-456d-b328-1a8a447c112c.png)
this results as a truncated string being inserted in the `content` column and being unable to unserialize it later.
This behaviour can be reproduced in the test suite by using a PostegreSQL database instead of a sqlite one.

Using base64, we can sidestep this issue, the zero byte will only "live" in PHP, and never be inserted in PostgreSQL.

Unfotunately, using base64 will end up being a breaking change for those that are currently using a PostgreSQL database, although I would imagine that already implemented some form of workaround because they would have been impacted by this bug already.
